### PR TITLE
Replace fs.rename with moveFile to stop errors on upload due to cross-fs links

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function error(req, res, error) {
 function moveFile(oldPath, newPath, callback) {
 	fs.rename(oldPath, newPath, function (err) {
 		if (err) {
-			if (err.code === 'EXDEV') {
+			if (err.code === "EXDEV") {
 				copy();
 			} else {
 				callback(err);
@@ -62,10 +62,10 @@ function moveFile(oldPath, newPath, callback) {
 		var readStream = fs.createReadStream(oldPath);
 		var writeStream = fs.createWriteStream(newPath);
 
-		readStream.on('error', callback);
-		writeStream.on('error', callback);
+		readStream.on("error", callback);
+		writeStream.on("error", callback);
 
-		readStream.on('close', function () {
+		readStream.on("close", function () {
 			fs.unlink(oldPath, callback);
 		});
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,34 @@ function error(req, res, error) {
 	}
 }
 
+function moveFile(oldPath, newPath, callback) {
+	fs.rename(oldPath, newPath, function (err) {
+		if (err) {
+			if (err.code === 'EXDEV') {
+				copy();
+			} else {
+				callback(err);
+			}
+			return;
+		}
+		callback();
+	});
+
+	function copy() {
+		var readStream = fs.createReadStream(oldPath);
+		var writeStream = fs.createWriteStream(newPath);
+
+		readStream.on('error', callback);
+		writeStream.on('error', callback);
+
+		readStream.on('close', function () {
+			fs.unlink(oldPath, callback);
+		});
+
+		readStream.pipe(writeStream);
+	}
+}
+
 app.use(promBundle({
 	includeMethod: true,
 	includePath: true,
@@ -88,7 +116,7 @@ app.post("/upload", (req, res) => {
 		}
 	} while (fs.exists(`${config.imagePath}/${name}${ext}`));
 
-	fs.rename(file.file, `${config.imagePath}/${name}${ext}`, err => {
+	moveFile(file.file, `${config.imagePath}/${name}${ext}`, err => {
 		if (err) {
 			return console.error(err);
 		}


### PR DESCRIPTION
To stop this from happening on machines with /tmp on tmpfs: ![](https://i.crzd.me/LBY5twjt.png)